### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ An improved implementation of persistent memory using a local knowledge graph wi
 
 This lets Claude remember information about the user across chats.
 
+<a href="https://glama.ai/mcp/servers/@itseasy21/mcp-knowledge-graph">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@itseasy21/mcp-knowledge-graph/badge" alt="Knowledge Graph Memory Server MCP server" />
+</a>
+
 > [!NOTE]
 > This is a fork of the original [Memory Server](https://github.com/modelcontextprotocol/servers/tree/main/src/memory) and is intended to not use the ephemeral memory npx installation method.
 


### PR DESCRIPTION
This PR adds a badge for the [Knowledge Graph Memory Server](https://glama.ai/mcp/servers/@itseasy21/mcp-knowledge-graph) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@itseasy21/mcp-knowledge-graph">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@itseasy21/mcp-knowledge-graph/badge" alt="Knowledge Graph Memory Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an image badge linking to the MCP Knowledge Graph server on glama.ai near the top of the README.
  * Minor whitespace adjustment at the end of the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->